### PR TITLE
chore: publish to npm to resolve `The remote archive does not match the expected checksum`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-webview",
+  "name": "@coolwallet-app/react-native-webview",
   "description": "React Native WebView component for iOS, Android, macOS, and Windows",
   "main": "index.js",
   "main-internal": "src/index.ts",
@@ -10,7 +10,11 @@
     "Thibault Malbranche <malbranche.thibault@gmail.com>"
   ],
   "license": "MIT",
-  "version": "13.13.4",
+  "version": "13.13.4-cbx.3",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "homepage": "https://github.com/react-native-webview/react-native-webview#readme",
   "scripts": {
     "android": "react-native run-android",
@@ -26,6 +30,7 @@
     "prepare": "yarn prepare:types && yarn build",
     "appium": "appium",
     "test:windows": "yarn jest --setupFiles=./jest-setups/jest.setup.js",
+    "publish:npm": "yarn publish",
     "add:macos": "yarn add react-native-macos@0.73.17"
   },
   "rn-docs": {


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR updates the `react-native-webview` package name to `@coolwallet-app/react-native-webview` and version to `13.13.4-cbx.3`. It also adds a publish configuration for public access to the npm registry and a new npm publish script. These changes aim to resolve checksum mismatch issues when installing the package.

**Key Changes**
- Updated package name to `@coolwallet-app/react-native-webview`.
- Updated package version to `13.13.4-cbx.3`.
- Added `publishConfig` for public access to the npm registry.
- Added `publish:npm` script to simplify publishing.

**Recommendations**
Ready for deployment. This simple change effectively addresses the checksum issue and improves the package management process.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 5 (71.4%)      |
| Refactor    | 2 (28.6%)      |
| Total Changes | 7             |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>