### PR TITLE
chore: bump version to 13.13.4-cbx.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "Thibault Malbranche <malbranche.thibault@gmail.com>"
   ],
   "license": "MIT",
-  "version": "13.13.4-cbx.3",
+  "version": "13.13.4-cbx.4",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
as title
 
 **PR Summary by Typo**
------------

**Overview**
This PR bumps the package version from 13.13.4-cbx.3 to 13.13.4-cbx.4 in `package.json`.  This likely represents a patch or minor update.

**Key Changes**
- Updated the `version` field in `package.json`.

**Recommendations**
Ready for deployment. This is a simple version bump with no apparent impact on functionality.

### 🗂️ Work Breakdown

| Category | Lines Changed |
|---|---|
| Rework | 1 (100%) |
| Total Changes | 1 |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>