### PR TITLE
🐛 [CW-26589] fix: 優化 Android 權限請求彈窗會非同步執行的問題

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
@@ -158,14 +158,11 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
         ArrayList<String> requestedAndroidPermissions = new ArrayList<>();
         for (String requestedResource : request.getResources()) {
             String androidPermission = null;
-            String requestPermissionIdentifier = null;
 
             if (requestedResource.equals(PermissionRequest.RESOURCE_AUDIO_CAPTURE)) {
                 androidPermission = Manifest.permission.RECORD_AUDIO;
-                requestPermissionIdentifier = "microphone";
             } else if (requestedResource.equals(PermissionRequest.RESOURCE_VIDEO_CAPTURE)) {
                 androidPermission = Manifest.permission.CAMERA;
-                requestPermissionIdentifier = "camera";
             } else if(requestedResource.equals(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)) {
                 if (mAllowsProtectedMedia) {
                   grantedPermissions.add(requestedResource);
@@ -180,36 +177,43 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
                   androidPermission = PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID;
                 }
             }
-            Uri originUri = request.getOrigin();
-            String host = originUri.getHost();
+
             // TODO: RESOURCE_MIDI_SYSEX, RESOURCE_PROTECTED_MEDIA_ID.
-            String alertMessage = String.format("Allow " + host  + " to use your " + requestPermissionIdentifier + "?");
             if (androidPermission != null) {
                 if (ContextCompat.checkSelfPermission(this.mWebView.getThemedReactContext(), androidPermission) == PackageManager.PERMISSION_GRANTED) {
-                    AlertDialog.Builder builder = new AlertDialog.Builder(this.mWebView.getContext());
-                    builder.setMessage(alertMessage);
-                    builder.setCancelable(false);
-                    String finalAndroidPermission = androidPermission;
-                    builder.setPositiveButton("Allow", (dialog, which) -> {
-                        permissionRequest = request;
-                        grantedPermissions.add(finalAndroidPermission);
-                        requestPermissions(grantedPermissions);
-                    });
-                    builder.setNegativeButton("Don't allow", (dialog, which) -> {
-                        request.deny();
-                    });
-                    AlertDialog alertDialog = builder.create();
-                    alertDialog.show();
-                    //Delay making `allow` clickable for 500ms to avoid unwanted presses.
-                    Button posButton = alertDialog.getButton(AlertDialog.BUTTON_POSITIVE);
-                    posButton.setEnabled(false);
-                    this.runDelayed(() -> posButton.setEnabled(true), 500);
+                    grantedPermissions.add(requestedResource);
                 } else {
                     requestedAndroidPermissions.add(androidPermission);
                 }
             }
         }
 
+        if (this.shouldShowRequestPermissionDialog(grantedPermissions)) {
+            String alertMessage = this.getRequestPermissionAlertMessage(request, grantedPermissions);
+
+            this.showRequestPermissionDialog(
+                    alertMessage,
+                    (dialog, which) -> {
+                        this.grantOrRequestPermission(request, requestedAndroidPermissions);
+                    },
+                    (dialog, which) -> {
+                        request.deny();
+                    });
+        } else {
+            this.grantOrRequestPermission(request, requestedAndroidPermissions);
+        }
+    }
+
+    // CW-22083: 如果網頁要求麥克風或攝影機權限，就顯示權限請求對話框。
+    // 參數只需要傳入已經被授權的權限即可。未授權的權限會由手機系統的權限請求對話框處理。
+    private boolean shouldShowRequestPermissionDialog(List<String> grantedPermissions) {
+        return grantedPermissions.contains(PermissionRequest.RESOURCE_AUDIO_CAPTURE) ||
+                grantedPermissions.contains(PermissionRequest.RESOURCE_VIDEO_CAPTURE);
+    }
+
+    // 如果 requestedAndroidPermissions 為空，表示手機系統已經給予所有權限給 app。app 可以直接 grant 權限給 webview。
+    // 如果 requestedAndroidPermissions 不為空，表示 app 還需要向手機系統請求權限，後續會有 listener 會再 grant 權限給 webview。
+    private void grantOrRequestPermission(PermissionRequest request, List<String> requestedAndroidPermissions) {
         // If all the permissions are already granted, send the response to the WebView synchronously
         if (requestedAndroidPermissions.isEmpty()) {
             if (!grantedPermissions.isEmpty()) {
@@ -224,6 +228,51 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
         this.permissionRequest = request;
 
         requestPermissions(requestedAndroidPermissions);
+    }
+
+    private String getDisplayHostName(PermissionRequest request) {
+        try {
+            Uri originUri = request.getOrigin();
+            return originUri.getHost(); 
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private String getRequestPermissionAlertMessage(PermissionRequest request, List<String> permissions) {        
+        List<String> permissionNames = new ArrayList<>();
+        for (String permission : permissions) {
+            switch (permission) {
+                case PermissionRequest.RESOURCE_AUDIO_CAPTURE:
+                    permissionNames.add("microphone");
+                    break;
+                case PermissionRequest.RESOURCE_VIDEO_CAPTURE:
+                    permissionNames.add("camera");
+                    break;
+                default:
+                    // Skip unknown permissions, just handle audio & video
+                    break;
+            }
+        }
+
+        String host = this.getDisplayHostName(request);
+        String permissionNamesJoined = String.join(" and ", permissionNames);
+
+        return String.format("Allow " + host  + " to use your " + permissionNamesJoined + "?");
+    }   
+
+    private void showRequestPermissionDialog(String alertMessage, DialogInterface.OnClickListener onAllow, DialogInterface.OnClickListener onDeny) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this.mWebView.getContext());
+        builder.setMessage(alertMessage);
+        builder.setCancelable(false);
+        builder.setPositiveButton("Allow", onAllow);
+        builder.setNegativeButton("Don't allow", onDeny);
+        AlertDialog alertDialog = builder.create();
+        alertDialog.show();
+        //Delay making `allow` clickable for 500ms to avoid unwanted presses.
+        Button posButton = alertDialog.getButton(AlertDialog.BUTTON_POSITIVE);
+        posButton.setEnabled(false);
+        this.runDelayed(() -> posButton.setEnabled(true), 500);
     }
 
     private void runDelayed(Runnable function, long delayMillis) {


### PR DESCRIPTION
### 說明
這個 PR 主要是修復 Dialog 非同步執行的問題。

### 修復前
當網頁在一個請求中要求兩個以上的權限時，有可能會觸發兩次 request.grant 導致 crash，範例影片：

https://github.com/user-attachments/assets/7f177471-3753-47a5-aa63-c82c048d7f2f



### 修復後
此 PR 調整過後，可以避免 crash，但由於未知原因，Microphone 無法授權成功(並非此 PR 改動造成)，範例影片：

https://github.com/user-attachments/assets/00259eaa-265a-47b5-af7d-2f7dd08d804e





 
 **PR Summary by Typo**
------------

#### Overview
This PR optimizes the handling of Android permission request dialogs in the WebView, specifically addressing an issue where custom permission pop-ups were being displayed asynchronously even when system permissions were already granted. The changes aim to streamline the permission request flow and ensure a more predictable user experience.

#### Key Changes
- Refactored the `onPermissionRequest` method to separate logic for checking existing system permissions from displaying custom permission dialogs.
- Introduced new helper methods (`shouldShowRequestPermissionDialog`, `grantOrRequestPermission`, `getDisplayHostName`, `getRequestPermissionAlertMessage`, `showRequestPermissionDialog`) to encapsulate dialog creation and permission handling.
- The custom permission dialog is now only displayed for microphone and camera resources if the application already possesses the necessary system permissions, preventing redundant or out-of-sync dialogs.
- The system's permission request dialog is now implicitly relied upon when the application does not yet have the required permissions.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 71 (74.7%)    |
| Churn       | 22 (23.2%)    |
| Refactor    | 2 (2.1%)      |
| Total Changes | 95          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>