### PR TITLE
🐛 [CW-26589] fix: 修復 Android 在 Bridge KYC 網頁一直跳出相機權限請求的彈窗

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/GrantedPermissionManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/GrantedPermissionManager.java
@@ -1,0 +1,45 @@
+package com.reactnativecommunity.webview;
+
+import java.util.*;
+
+public class GrantedPermissionManager {
+  private Map<String, Set<String>> map; // key: host, value: granted permissions
+
+  public GrantedPermissionManager() {
+    map = new HashMap<>();
+  }
+
+  // use synchronized to make thread-safe
+  public synchronized void add(String host, List<String> permissions) {
+    if (host == null || host.isEmpty() || permissions == null || permissions.isEmpty()) {
+      return;
+    }
+    if (!map.containsKey(host)) {
+      map.put(host, new HashSet<>());
+    }
+    Set<String> grantedPermissions = map.get(host);
+    grantedPermissions.addAll(getValidPermissions(permissions));
+  }
+
+  // use synchronized to make thread-safe
+  public synchronized boolean containsAll(String host, List<String> permissions) {
+    if (host == null || host.isEmpty() || permissions == null || permissions.isEmpty()) {
+      return false;
+    }
+    return map.containsKey(host) &&
+        map.get(host).containsAll(getValidPermissions(permissions));
+  }
+
+  private List<String> getValidPermissions(List<String> permissions) {
+    List<String> cleaned = new ArrayList<>();
+    if (permissions == null || permissions.isEmpty()) {
+      return cleaned;
+    }
+    for (String permission : permissions) {
+      if (permission != null && !permission.isEmpty()) {
+        cleaned.add(permission);
+      }
+    }
+    return cleaned;
+  }
+}

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
@@ -89,8 +89,11 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
 
     protected boolean mHasOnOpenWindowEvent = false;
 
+    private GrantedPermissionManager grantedPermissionManager;
+
     public RNCWebChromeClient(RNCWebView webView) {
         this.mWebView = webView;
+        this.grantedPermissionManager = new GrantedPermissionManager();
     }
 
     @Override
@@ -188,12 +191,15 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
             }
         }
 
-        if (this.shouldShowRequestPermissionDialog(grantedPermissions)) {
-            String alertMessage = this.getRequestPermissionAlertMessage(request, grantedPermissions);
+        String host = this.getUrlHostSafely(request);
+
+        if (this.shouldShowRequestPermissionDialog(host, grantedPermissions)) {
+            String alertMessage = this.getRequestPermissionAlertMessage(host, grantedPermissions);
 
             this.showRequestPermissionDialog(
                     alertMessage,
                     (dialog, which) -> {
+                        grantedPermissionManager.add(host, grantedPermissions);
                         this.grantOrRequestPermission(request, requestedAndroidPermissions);
                     },
                     (dialog, which) -> {
@@ -206,9 +212,13 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
 
     // CW-22083: 如果網頁要求麥克風或攝影機權限，就顯示權限請求對話框。
     // 參數只需要傳入已經被授權的權限即可。未授權的權限會由手機系統的權限請求對話框處理。
-    private boolean shouldShowRequestPermissionDialog(List<String> grantedPermissions) {
-        return grantedPermissions.contains(PermissionRequest.RESOURCE_AUDIO_CAPTURE) ||
+    private boolean shouldShowRequestPermissionDialog(String host, List<String> grantedPermissions) {
+        boolean isAudioOrVideo = grantedPermissions.contains(PermissionRequest.RESOURCE_AUDIO_CAPTURE) ||
                 grantedPermissions.contains(PermissionRequest.RESOURCE_VIDEO_CAPTURE);
+        boolean hasUserSeenPermissionDialog = grantedPermissionManager.containsAll(
+                host,
+                grantedPermissions);
+        return isAudioOrVideo && !hasUserSeenPermissionDialog;
     }
 
     // 如果 requestedAndroidPermissions 為空，表示手機系統已經給予所有權限給 app。app 可以直接 grant 權限給 webview。
@@ -230,7 +240,7 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
         requestPermissions(requestedAndroidPermissions);
     }
 
-    private String getDisplayHostName(PermissionRequest request) {
+    private String getUrlHostSafely(PermissionRequest request) {
         try {
             Uri originUri = request.getOrigin();
             return originUri.getHost(); 
@@ -239,7 +249,7 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
         }
     }
 
-    private String getRequestPermissionAlertMessage(PermissionRequest request, List<String> permissions) {        
+    private String getRequestPermissionAlertMessage(String host, List<String> permissions) {        
         List<String> permissionNames = new ArrayList<>();
         for (String permission : permissions) {
             switch (permission) {
@@ -255,7 +265,6 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
             }
         }
 
-        String host = this.getDisplayHostName(request);
         String permissionNamesJoined = String.join(" and ", permissionNames);
 
         return String.format("Allow " + host  + " to use your " + permissionNamesJoined + "?");

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "Thibault Malbranche <malbranche.thibault@gmail.com>"
   ],
   "license": "MIT",
-  "version": "13.13.4-cbx.7",
+  "version": "13.13.4-cbx.8",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
### 說明
這個 PR 主要是修復 Android 操作 Bridge KYC 網頁時一直跳出相同權限請求的問題。

### 修復前

https://github.com/user-attachments/assets/2acc1585-54ed-4de7-9f82-8b7e2adffefd







### 修復後


https://github.com/user-attachments/assets/b13ff1a3-d11c-4057-9826-b05512ac7dab





 
 
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a bug in the Android WebView component that caused repeated camera permission requests on the Bridge KYC web page. It introduces a mechanism to track and manage granted permissions per host, preventing redundant permission dialogs.

#### Key Changes
- **Added `GrantedPermissionManager.java`:** A new utility class to store and manage permissions that have already been granted by the user for specific hosts.
- **Integrated `GrantedPermissionManager` into `RNCWebChromeClient`:** The `WebChromeClient` now uses this manager to determine if a permission dialog has already been shown for a given host and permission type.
- **Modified permission request logic:** The `shouldShowRequestPermissionDialog` function now checks the `GrantedPermissionManager` before displaying a permission dialog, ensuring it only appears once per host for a given permission.
- **Renamed `getDisplayHostName` to `getUrlHostSafely`:** Improved clarity and safety in retrieving the host name from a URL.
- **Version bump:** Updated `package.json` version to `13.13.4-cbx.8`.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 55 (87.3%)    |
| Churn       | 1 (1.6%)      |
| Rework      | 7 (11.1%)     |
| Total Changes | 63            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>